### PR TITLE
Add login form validation with Zod schema

### DIFF
--- a/src/components/forms/LoginForm.tsx
+++ b/src/components/forms/LoginForm.tsx
@@ -7,6 +7,7 @@ import PasswordInput from '../ui/PasswordInput';
 import Button from '../ui/Button';
 import Spinner from '../ui/Spinner';
 import { messages } from '../../lib/messages';
+import { loginUser } from '../../lib/login';
 
 const LoginForm: React.FC = () => {
     const {
@@ -25,6 +26,16 @@ const LoginForm: React.FC = () => {
         setLoading(true);
         setSuccessMsg('');
         setErrorMsg('');
+
+        try {
+            const res = await loginUser(data);
+            setSuccessMsg(messages.success.login);
+        } catch (err: any) {
+            const msg = err.response?.data?.message || messages.error.login;
+            setErrorMsg(msg);
+        } finally {
+            setLoading(false);
+        }
     };
 
     return (

--- a/src/hooks/LoginValidation.ts
+++ b/src/hooks/LoginValidation.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+    email: z.string()
+        .nonempty('Email is required')
+        .email('Invalid email address'),
+
+    password: z.string()
+        .nonempty('Password is required')
+        .min(6, 'Password must be at least 6 characters'),
+});
+
+export type LoginFormValues = z.infer<typeof loginSchema>;

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -1,0 +1,13 @@
+export type LoginFormInput = {
+    email: string;
+    password: string;
+};
+
+export async function loginUser(data: LoginFormInput) {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            console.log('📦 Mock logined user:', data);
+            resolve({ message: 'Mock login success' });
+        }, 1000);
+    });
+}

--- a/src/lib/login.ts
+++ b/src/lib/login.ts
@@ -6,7 +6,7 @@ export type LoginFormInput = {
 export async function loginUser(data: LoginFormInput) {
     return new Promise((resolve) => {
         setTimeout(() => {
-            console.log('📦 Mock logined user:', data);
+            console.log('📦 Mock login succeeded user:', data);
             resolve({ message: 'Mock login success' });
         }, 1000);
     });


### PR DESCRIPTION
### Included:
- `loginSchema` defined using `zod`, placed under `hooks/LoginValidation.ts`
- Validates:
  - Email presence and format
  - Password presence and minimum length
- Exported `LoginFormValues` type inferred from the schema

This follows the same structure as the existing registration validation, to ensure consistency across forms.