### PR TITLE
Protect routes and update navigation after user logout

### DIFF
--- a/src/routes/DashBoardRoutes.tsx
+++ b/src/routes/DashBoardRoutes.tsx
@@ -1,13 +1,21 @@
 import { RouteObject } from 'react-router-dom';
 import AppLayout from '../layouts/AppLayout';
 import Dashboard from '../pages/DashBoard';
+import ProtectedRoute from './ProtectedRoute';
 
 export const dashboardRoutes: RouteObject[] = [
     {
         path: '/',
         element: <AppLayout />,
         children: [
-            { path: '', element: <Dashboard /> }
+            {
+                path: '',
+                element: (
+                    <ProtectedRoute>
+                        <Dashboard />
+                    </ProtectedRoute>
+                )
+            }
         ]
     }
 ];

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import React, { JSX } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+type Props = {
+    children: JSX.Element;
+};
+
+const ProtectedRoute = ({ children }: Props): JSX.Element => {
+    const { user } = useAuth();
+
+    if (!user) {
+        return <Navigate to="/login" replace/>;
+    }
+
+    return children;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
## Summary
This PR ensures protected routes are only accessible by authenticated users and redirects unauthenticated users to the login page. It also updates the logout logic to properly clear auth state and navigation context.

## Changes
- Implemented <ProtectedRoute /> component to guard dashboard routes

- Wrapped Dashboard route with ProtectedRoute

- Ensured AuthContext clears user on logout

- Redirects to /login upon logout

- Disabled logout button while request is processing (UX polish)

## Why
- Without this, users can manually access authenticated pages via URL even after logging out. Proper routing protection improves both security and user experience.

## Notes
- Consider applying <ProtectedRoute /> to other private pages in the future

- Unit tests for routing and auth logic can be handled in a separate pass