### PR TITLE
fetch and display user profile data from /api/me

### DIFF
--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,11 +1,41 @@
-import React from 'react';
-import { mockUserProfile } from '../mock/userProfile';
+import React, { useEffect, useState } from 'react';
 import UserProfile from '../components/profile/UserProfile';
+import { UserProfile as UserProfileType } from '../lib/userProfile';
+import NotFound from "./NotFound";
+import Spinner from "../components/ui/Spinner";
+import {messages} from "../lib/messages";
 
 const UserProfilePage: React.FC = () => {
+    const [user, setUser] = useState<UserProfileType | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [errorMsg, setErrorMsg] = useState('');
+
+    useEffect(() => {
+        const fetchUser = async () => {
+            try {
+                const res = await fetch('/api/me');
+                if (!res.ok) throw new Error('Failed to fetch');
+
+                const data: UserProfileType = await res.json();
+                setUser(data);
+            } catch (err) {
+                console.error(err);
+                setErrorMsg(messages.error.unexpected);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchUser();
+    }, []);
+
+    if (loading) return <Spinner size="lg" className="mx-auto mt-20" />;
+    if (errorMsg) return <p className="text-red-600">{errorMsg}</p>;
+    if (!user) return <NotFound />;
+
     return (
         <main className="bg-gray-100 min-h-screen py-10 px-4">
-            <UserProfile user={mockUserProfile} />
+            <UserProfile user={user} />
         </main>
     );
 };

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -3,7 +3,7 @@ import UserProfile from '../components/profile/UserProfile';
 import { UserProfile as UserProfileType } from '../lib/userProfile';
 import NotFound from "./NotFound";
 import Spinner from "../components/ui/Spinner";
-import {messages} from "../lib/messages";
+import { messages } from "../lib/messages";
 
 const UserProfilePage: React.FC = () => {
     const [user, setUser] = useState<UserProfileType | null>(null);
@@ -14,7 +14,7 @@ const UserProfilePage: React.FC = () => {
         const fetchUser = async () => {
             try {
                 const res = await fetch('/api/me');
-                if (!res.ok) throw new Error('Failed to fetch');
+                if (!res.ok) throw new Error(messages.error.unexpected);
 
                 const data: UserProfileType = await res.json();
                 setUser(data);


### PR DESCRIPTION
## Overview

This pull request introduces the logic to fetch and render the authenticated user's profile data via the `/api/me` endpoint.

## Changes

- Created `UserProfilePage.tsx` to handle loading, error, and not-found states.
- Implemented `fetch` call to `/api/me` using `useEffect`.
- Integrated error handling using `try-catch` and `messages.error.unexpected`.
- Displayed `<NotFound />` component when no user is found.
- Included `<Spinner />` for loading feedback.

## Future considerations

- Redirect to login page on 401 unauthorised responses.
- Extract `fetchUserProfile()` to a service layer for reusability.
- Integrate authentication check before calling the API.