### PR TITLE
Implement protected route for authenticated user access

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useState, ReactNode } from 'react';
+import {
+    createContext,
+    useContext,
+    useState,
+    useEffect,
+    ReactNode,
+} from 'react';
 import { logoutUser } from '../lib/logout';
 import { User } from '../lib/user';
 
@@ -6,12 +12,34 @@ type AuthContextType = {
     user: User | null;
     setUser: (user: User | null) => void;
     logout: () => Promise<void>;
+    loading: boolean;
 };
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
     const [user, setUser] = useState<User | null>(null);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    useEffect(() => {
+        const checkAuth = async () => {
+            try {
+                const res = await fetch('/api/me');
+                if (res.ok) {
+                    const data = await res.json();
+                    setUser(data);
+                } else {
+                    setUser(null);
+                }
+            } catch (err) {
+                setUser(null);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        checkAuth();
+    }, []);
 
     const logout = async () => {
         try {
@@ -24,7 +52,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     };
 
     return (
-        <AuthContext.Provider value={{ user, setUser, logout }}>
+        <AuthContext.Provider value={{ user, setUser, logout, loading }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -1,16 +1,20 @@
-import React, { JSX } from 'react';
+import React, { ReactElement } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 type Props = {
-    children: JSX.Element;
+    children: ReactElement;
 };
 
-const ProtectedRoute = ({ children }: Props): JSX.Element => {
-    const { user } = useAuth();
+const ProtectedRoute = ({ children }: Props): ReactElement => {
+    const { user, loading } = useAuth();
+
+    if (loading) {
+        return <div>Loading...</div>;
+    }
 
     if (!user) {
-        return <Navigate to="/login" replace/>;
+        return <Navigate to="/login" replace />;
     }
 
     return children;


### PR DESCRIPTION
## Overview

This pull request introduces a protected routing mechanism to restrict access to certain routes (e.g. the user profile page) to authenticated users only.

## Changes

- Added `loading` state management to `AuthContext` to track the initial authentication status.
- Fetched the current user on mount via a call to `/api/me`.
- Extended `AuthContext` to provide the `loading` flag to consumers.
- Updated `ProtectedRoute` component to:
  - Show a loading indicator while authentication status is being determined.
  - Redirect unauthenticated users to the login page.

This ensures that private routes such as `/profile` are only accessible to logged-in users, and avoids flashing protected content during the initial render.