### PR TITLE
Conditionally render Header for authenticated users via AppLayout

### DIFF
--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,15 +1,25 @@
 import { Outlet } from 'react-router-dom';
-import {GlobalStyleControl} from "./GlobalStyleControl";
+import { GlobalStyleControl } from "./GlobalStyleControl";
+import Header from '../components/common/Header';
+import { useAuth } from '../context/AuthContext';
 import React from "react";
 
 const AppLayout: React.FC = () => {
+    const { user, loading } = useAuth();
+
+    if (loading) return null;
+
     return (
-        <main className="
-        min-h-screen flex items-center justify-center
-        bg-gradient-to-br from-indigo-50 to-purple-100 px-4 bg-stone-900">
-            <GlobalStyleControl />
-            <Outlet />
-        </main>
+        <>
+            {user && <Header />}
+            <main className="
+                min-h-screen flex items-center justify-center
+                bg-gradient-to-br from-indigo-50 to-purple-100 px-4 bg-stone-900"
+            >
+                <GlobalStyleControl />
+                <Outlet />
+            </main>
+        </>
     );
 };
 


### PR DESCRIPTION
## Overview

This pull request ensures that the `Header` component is only rendered for authenticated users.  
The conditional logic has been placed within `AppLayout.tsx`, where the authentication state is accessed via `useAuth()`.

By doing this, we avoid exposing the `Header` to unauthenticated users and keep layout responsibilities isolated from route-level configuration.

## Changes

- Updated `AppLayout.tsx` to:
  - Access the `user` and `loading` states from `AuthContext`
  - Render the `Header` component only if the user is present
  - Prevent layout flickering by guarding with a loading state check

- No changes made to `dashboardRoutes`, as layout-level responsibility handles header visibility.

## Behaviour

- The `Header` now only appears for users who are logged in.
- Unauthenticated users see no `Header` while accessing routes like `/login` or `/signup`.
- The routing structure remains clean and focused solely on page-level logic.
