### PR TITLE
Synchronise profile image updates across UserProfilePage and Header via AuthContext

### DIFF
--- a/src/components/profile/profile-image-uploader/ProfileImageUploader.tsx
+++ b/src/components/profile/profile-image-uploader/ProfileImageUploader.tsx
@@ -1,24 +1,29 @@
 import React from 'react';
 import { ProfileImageUploaderProps } from './ProfileImageUploader.types';
 
-const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({ user, previewUrl, onFileChange, errorMsg }) => {
+const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({
+    user,
+    uploadedImageUrl,
+    previewUrl,
+    onFileChange,
+    errorMsg,
+    successMsg,
+}) => {
     return (
-        <div className="bg-white rounded-xl shadow-md p-4 sm:p-6 w-full max-w-md md:max-w-2xl lg:max-w-3xl mx-auto">
-            <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
+        <div className="bg-white rounded-xl shadow-md p-4 w-full max-w-md mx-auto">
+            <div className="flex flex-col items-center gap-4">
                 <img
-                    src={previewUrl || user.profileImage}
+                    src={uploadedImageUrl ?? previewUrl ?? user.profileImage}
                     alt="Avatar"
-                    className="w-24 h-24 sm:w-20 sm:h-20 rounded-full object-cover border border-gray-300"
+                    className="w-24 h-24 rounded-full object-cover border border-gray-300"
                 />
-                <div className="text-center sm:text-left">
-                    <h2 className="text-lg sm:text-xl font-semibold text-gray-800">
-                        {user.firstName} {user.lastName}
-                    </h2>
-                </div>
+                <h2 className="text-lg font-semibold text-gray-800">
+                    {user.firstName} {user.lastName}
+                </h2>
             </div>
 
-            <div className="mt-4 flex flex-col items-center">
-                <label className="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white text-sm py-2 px-4 rounded">
+            <div className="mt-4 text-center">
+                <label className="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white py-2 px-4 rounded">
                     Upload New Profile Image
                     <input
                         type="file"
@@ -32,6 +37,11 @@ const ProfileImageUploader: React.FC<ProfileImageUploaderProps> = ({ user, previ
             {errorMsg && (
                 <p className="text-red-600 bg-red-100 rounded p-2 mt-2 text-center text-sm">
                     {errorMsg}
+                </p>
+            )}
+            {successMsg && (
+                <p className="text-green-600 bg-green-100 rounded p-2 mt-2 text-center text-sm">
+                    {successMsg}
                 </p>
             )}
         </div>

--- a/src/components/profile/profile-image-uploader/ProfileImageUploader.types.ts
+++ b/src/components/profile/profile-image-uploader/ProfileImageUploader.types.ts
@@ -2,7 +2,8 @@ import { UserProfile } from '../../../lib/user-profile';
 
 export type ProfileImageUploaderProps = {
     user: UserProfile;
-    previewUrl: string | null ;
+    uploadedImageUrl?: string | null;
+    previewUrl?: string | null;
     onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     errorMsg?: string | null;
     successMsg?: string | null;

--- a/src/components/profile/profile-image-uploader/ProfileImageUploaderContainer.tsx
+++ b/src/components/profile/profile-image-uploader/ProfileImageUploaderContainer.tsx
@@ -2,8 +2,8 @@ import React, { useState, useEffect } from 'react';
 import ProfileImageUploader from './ProfileImageUploader';
 import { UserProfile } from '../../../lib/user-profile';
 import { validateProfileImage } from '../../../hooks/upload-profile-validation';
-import { uploadProfileImageMock } from '../../../lib/upload-profile-image';
-import {messages} from "../../../lib/messages";
+import { uploadProfileImageMock } from '../../../mock/upload-profile-image';
+import { messages } from "../../../lib/messages";
 
 type Props = {
     userProfile: UserProfile;
@@ -16,26 +16,21 @@ const ProfileImageUploaderContainer: React.FC<Props> = ({ userProfile }) => {
     const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
     useEffect(() => {
-        return () => {
-            if (previewUrl) {
-                URL.revokeObjectURL(previewUrl);
-            }
-        };
-    }, [previewUrl]);
+        if (uploadedImageUrl) {
+            console.log("🟢 uploadedImageUrl:", uploadedImageUrl);
+        }
+    }, [uploadedImageUrl]);
 
     const handleUpload = async (file: File) => {
         try {
             const { profileImage } = await uploadProfileImageMock(file);
-
-            if (!profileImage) {
-                throw new Error(messages.error.upload.default);
-            }
+            if (!profileImage) throw new Error(messages.error.upload.default);
 
             setUploadedImageUrl(profileImage);
             setSuccessMsg(messages.success.upload.success);
             setErrorMsg(null);
         } catch (error) {
-            console.error('Upload failed', error instanceof Error ? error.message : error);
+            console.error('Upload failed', error);
             setErrorMsg(messages.error.upload.default);
             setSuccessMsg(null);
         }
@@ -70,7 +65,8 @@ const ProfileImageUploaderContainer: React.FC<Props> = ({ userProfile }) => {
     return (
         <ProfileImageUploader
             user={userProfile}
-            previewUrl={uploadedImageUrl ?? previewUrl ?? null}
+            previewUrl={previewUrl}
+            uploadedImageUrl={uploadedImageUrl}
             onFileChange={handleFileChange}
             errorMsg={errorMsg}
             successMsg={successMsg}

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -4,13 +4,15 @@ import {
     useState,
     useEffect,
     ReactNode,
+    Dispatch,
+    SetStateAction,
 } from 'react';
 import { logoutUser } from '../lib/logout';
 import { User } from '../lib/user';
 
 type AuthContextType = {
     user: User | null;
-    setUser: (user: User | null) => void;
+    setUser: Dispatch<SetStateAction<User | null>>;
     logout: () => Promise<void>;
     loading: boolean;
 };

--- a/src/lib/upload-profile-image.ts
+++ b/src/lib/upload-profile-image.ts
@@ -1,18 +1,7 @@
-import { mockUserProfile } from "../mock/user-profile";
-import { UserProfile } from "./user-profile";
-
-export const uploadProfileImageMock = async (file: File): Promise<UserProfile> => {
+export const uploadProfileImageMock = async (file: File): Promise<{ profileImage: string }> => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
-
     const newImageUrl = URL.createObjectURL(file);
     return {
-        ...mockUserProfile,
-        id: mockUserProfile.id,
-        firstName: mockUserProfile.firstName,
-        lastName: mockUserProfile.lastName,
-        email: mockUserProfile.email,
         profileImage: newImageUrl,
-        bio: mockUserProfile.bio,
-        skills: mockUserProfile.skills,
     };
 };

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -7,4 +7,5 @@ export type User = {
     location?: string;
     skills?: string[];
     profileImage?: string;
+
 };

--- a/src/mock/user-profile.ts
+++ b/src/mock/user-profile.ts
@@ -5,7 +5,7 @@ export const mockUserProfile: UserProfile = {
     firstName: 'Cristiano',
     lastName: 'Ronaldo',
     email: 'ogi@example.com',
-    profileImage: 'https://i.pravatar.cc/150?img=5',
+    profileImage: '',
     bio: 'Laravel + React developer',
     skills: ['Laravel', 'React', 'TypeScript'],
 };

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -1,59 +1,55 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ProfileImageUploader from '../components/profile/profile-image-uploader/ProfileImageUploader';
-import { UserProfile as UserProfileType } from '../lib/user-profile';
-import NotFound from "./NotFound";
 import Spinner from "../components/ui/Spinner";
 import { messages } from "../lib/messages";
-import {ErrorMessage} from "../components/ui/ErrorMessage";
+import { ErrorMessage } from "../components/ui/ErrorMessage";
+import NotFound from "./NotFound";
+import { useAuth } from "../context/AuthContext";
 
 const UserProfilePage: React.FC = () => {
-    const [user, setUser] = useState<UserProfileType | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [errorMsg, setErrorMsg] = useState('');
+    const { user, setUser, loading } = useAuth();
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
+    const [errorMsg, setErrorMsg] = useState<string | null>(null);
+    const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
-    useEffect(() => {
-        const fetchUser = async () => {
-            try {
-                const isMock = 'true';
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file || !user) return;
 
-                if (isMock) {
-                    const mockUser: UserProfileType = {
-                        id: 1,
-                        firstName: 'Mock',
-                        lastName: 'User',
-                        email: 'mock@example.com',
-                        bio: 'This is a mock bio.',
-                        location: 'Tokyo, Japan',
-                        skills: ['React', 'TypeScript', 'Tailwind'],
-                        profileImage: 'https://i.pravatar.cc/150?u=mock',
-                    };
-                    setUser(mockUser);
-                    return;
-                }
+        const newPreviewUrl = URL.createObjectURL(file);
+        setPreviewUrl(newPreviewUrl);
+        setSuccessMsg(null);
+        setErrorMsg(null);
 
-                const res = await fetch('/api/me');
-                if (!res.ok) throw new Error(messages.error.unexpected);
+        const reader = new FileReader();
+        reader.onloadend = () => {
+            if (typeof reader.result === 'string') {
+                const newImage = reader.result;
 
-                const data: UserProfileType = await res.json();
-                setUser(data);
-            } catch (err) {
-                console.error(err);
-                setErrorMsg(messages.error.unexpected);
-            } finally {
-                setLoading(false);
+                setUploadedImageUrl(newImage);
+                setSuccessMsg(messages.success.upload.success);
+
+                setUser(prev => prev ? { ...prev, profileImage: newImage } : prev);
             }
         };
-
-        fetchUser();
-    }, []);
+        reader.readAsDataURL(file);
+    };
 
     if (loading) return <Spinner size="lg" className="mx-auto mt-20" />;
-    if (errorMsg) return <ErrorMessage message={errorMsg}/>;
+    if (errorMsg) return <ErrorMessage message={errorMsg} />;
     if (!user) return <NotFound />;
 
     return (
         <main className="bg-gray-100 min-h-screen py-10 px-4">
-            <ProfileImageUploader user={user} />
+            <ProfileImageUploader
+                user={user}
+                previewUrl={previewUrl}
+                uploadedImageUrl={uploadedImageUrl}
+                onFileChange={handleFileChange}
+                errorMsg={errorMsg}
+                successMsg={successMsg}
+            />
         </main>
     );
 };


### PR DESCRIPTION
## Overview
This pull request ensures that the user's updated profile image—when changed on the UserProfilePage—is immediately reflected in the global application state, including the Header component.

## Key Changes
- Integrated `useAuth()` in `UserProfilePage` to use the global `user` and `setUser`.
- On successful image upload, updated the `user.profileImage` field via `setUser`, which is managed through `AuthContext`.
- Ensured that the `Header` re-renders with the latest profile image without requiring a full page reload.
- Corrected `setUser` type in `AuthContext` to allow functional updates (`prev => ...`) by applying `Dispatch<SetStateAction<User | null>>`.

## Context
Previously, even after uploading a new profile image, the Header continued displaying the old one due to `user` being locally managed in the profile page and not updating the shared context. This fix aligns local updates with global state.

## Related Issues
- None linked directly
