### PR TITLE
Define types for PasswordResetRequestForm component

### DIFF
--- a/src/features/auth/password-reset/PasswordResetRequestFormContainer.tsx
+++ b/src/features/auth/password-reset/PasswordResetRequestFormContainer.tsx
@@ -1,16 +1,8 @@
 import React from 'react';
 import Spinner from '../../../components/ui/Spinner';
+import { PasswordResetRequestFormProps } from './type';
 
-type Props = {
-    email: string;
-    onEmailChange: (email: string) => void;
-    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
-    loading?: boolean;
-    successMsg: string | null;
-    errorMsg: string | null;
-};
-
-const PasswordResetRequestFormContainer: React.FC<Props> =
+const PasswordResetRequestFormContainer: React.FC<PasswordResetRequestFormProps> =
     ({
          email,
          onEmailChange,

--- a/src/features/auth/password-reset/type.ts
+++ b/src/features/auth/password-reset/type.ts
@@ -1,0 +1,8 @@
+export type PasswordResetRequestFormProps = {
+    email: string;
+    onEmailChange: (email: string) => void;
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    loading?: boolean;
+    successMsg: string | null;
+    errorMsg: string | null;
+};


### PR DESCRIPTION
## Overview
This pull request introduces a dedicated type definition file for the `PasswordResetRequestForm` component.  
It extracts and organises the props interface into a shared location to improve reusability, readability, and maintenance across related modules.

## Key Changes
- Created `type.ts` under `features/auth/password-request/`
- Defined `PasswordResetRequestFormProps` type for use in both UI and container
- Updated `PasswordResetRequestForm.tsx` to consume the imported type instead of inline definition