### PR TITLE
Integrate validation schema for new password fields using Zod

### DIFF
--- a/src/features/auth/password-reset/PasswordResetContainer.tsx
+++ b/src/features/auth/password-reset/PasswordResetContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { messages } from '../../../lib/messages';
 import PasswordResetForm from '../../../components/auth/PasswordResetForm';
+import { passwordResetSchema } from '../../../hooks/validation/password-reset';
 
 const PasswordResetConfirmContainer: React.FC = () => {
     const [password, setPassword] = useState('');
@@ -14,8 +15,11 @@ const PasswordResetConfirmContainer: React.FC = () => {
         setSuccessMsg('');
         setErrorMsg('');
 
-        if (password !== confirmPassword) {
-            setErrorMsg(messages.error.reset.password.notMatch);
+        const result = passwordResetSchema.safeParse({ password, confirmPassword });
+
+        if (!result.success) {
+            const firstError = result.error.errors[0]?.message || messages.error.reset.password.default;
+            setErrorMsg(firstError);
             return;
         }
 

--- a/src/hooks/validation/password-reset.ts
+++ b/src/hooks/validation/password-reset.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { messages } from '../../lib/messages';
+
+export const passwordResetSchema = z.object({
+    password: z.string()
+        .nonempty(messages.error.password.null)
+        .min(8, messages.error.password.minLength(8))
+        .max(255, messages.error.password.maxLength(255))
+        .regex(
+            /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).+$/,
+            messages.error.reset.password.invalidFormat,
+        ),
+
+    confirmPassword: z.string().nonempty(messages.error.password.null),
+}).refine((data) => data.password === data.confirmPassword, {
+    message: messages.error.reset.password.notMatch,
+    path: ['confirmPassword'],
+});

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -51,9 +51,11 @@ export const messages = {
             password: {
                 default: 'Password reset failed. Please try again.',
                 null: 'Password is required.',
-                minLength: (min: number) => `Password must be at least ${ min } characters long.`,
-                maxLength: (max: number) => `Password must be at most ${ max } characters long.`,
+                minLength: (min: number) => `Password must be at least ${min} characters long.`,
+                maxLength: (max: number) => `Password must be at most ${max} characters long.`,
                 notMatch: 'Passwords do not match.',
+                weak: 'Password is too weak. Include a mix of letters, numbers, and symbols.',
+                invalidFormat: 'Password must include at least one uppercase letter, one lowercase letter, and one number.',
             },
             email: {
                 default: 'Failed to send email. Please try again.',


### PR DESCRIPTION
## Overview

This PR completes the implementation of a validation schema for the password reset form.  
By using `Zod`, we ensure that both the `password` and `confirmPassword` fields meet format and consistency requirements prior to submitting the password reset request.

## What's Included

- Added a dedicated schema: `passwordResetSchema` under `hooks/validation/password-reset-confirm.ts`
- Enforced the following validations:
  - `password`: required, min/max length, format must include at least one lowercase letter, one uppercase letter, and one number
  - `confirmPassword`: required and must match `password`
- Replaced manual validation logic in `PasswordResetConfirmContainer.tsx` with `safeParse(...)` using the schema
- Centralised validation error messages using `messages.error.reset.password.*`

## Why it matters

- Ensures consistency and correctness across form validations
- Makes the validation layer testable and maintainable
- Improves user experience with immediate, specific error messages
- Fully decouples UI and validation rules

## Affected Areas

- `PasswordResetConfirmContainer.tsx`
- `password-reset-confirm.ts` (new schema definition)
- `messages.ts` (if `invalidFormat` or `notMatch` keys were added)