### PR TITLE
feat: connect-password-reset-mock-api

### DIFF
--- a/src/lib/password-reset-confirm.ts
+++ b/src/lib/password-reset-confirm.ts
@@ -1,0 +1,14 @@
+export type PasswordResetConfirmInput = {
+    token: string;
+    password: string;
+    passwordConfirmation: string;
+};
+
+export async function requestPasswordResetConfirm(data: PasswordResetConfirmInput) {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            console.log("✅ Password reset confirmed with:", data);
+            resolve({ message: "Password reset success" });
+        }, 1000);
+    });
+}


### PR DESCRIPTION
This PR connects the PasswordResetForm component to a mock password reset confirmation API.

### Changes:
- Retrieves password reset token from the URL query string (?token=xxx)
- Validates new password and confirmation using Zod schema
- Sends a request via requestPasswordResetConfirm() mock function
- Handles loading, success, and error states appropriately
- Passes state and handlers to PasswordResetForm presentational component