### PR TITLE
Define Zod schema for user profile form validation

### DIFF
--- a/src/components/forms/registration-form/RegistrationForm.types.ts
+++ b/src/components/forms/registration-form/RegistrationForm.types.ts
@@ -3,5 +3,4 @@ export type RegistrationFormValues = {
     lastName: string;
     email: string;
     password: string;
-    value: string;
 };

--- a/src/hooks/validation/user-profile-edit.ts
+++ b/src/hooks/validation/user-profile-edit.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { messages } from '../../lib/messages';
+
+export const userProfileEditSchema = z.object({
+    firstName: z.string()
+        .nonempty(messages.error.required('First Name'))
+        .min(2, messages.error.min('First Name', 2)),
+
+    lastName: z.string()
+        .nonempty(messages.error.required('Last Name'))
+        .min(2, messages.error.min('Last Name', 2)),
+
+    bio: z.string()
+        .max(500, messages.error.max('Bio', 500))
+        .optional(),
+
+    location: z.string()
+        .max(255, messages.error.max('Location', 255))
+        .optional(),
+});
+
+export type UserProfileEditFormValues = z.infer<typeof userProfileEditSchema>;


### PR DESCRIPTION
### Changes:
- Added `userProfileSchema.ts` under `validation/`
- Fields included in schema:
  - `firstName`: required, minimum 2 characters
  - `lastName`: required, minimum 2 characters
  - `bio`: optional, max 500 characters
  - `location`: optional, max 255 characters
- Custom error messages are handled via the `messages` module
- Added `UserProfileFormValues` type using `z.infer`

### Notes:
- This schema is defined independently for now, but is structured for easy migration to field-level shared validation in the future
- Integration with `react-hook-form` and UI form is assumed to follow separately