### PR TITLE
Toggle editable and read-only profile display

### DIFF
--- a/src/components/profile/UserProfileReadOnlyCard.tsx
+++ b/src/components/profile/UserProfileReadOnlyCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { User } from '../../lib/user';
+
+type Props = {
+    user: User;
+};
+
+const UserProfileReadOnlyCard: React.FC<Props> = ({ user }) => {
+    return (
+        <div className="bg-white p-6 rounded shadow space-y-2">
+            <p><strong>Name:</strong> {user.firstName} {user.lastName}</p>
+            <p><strong>Email:</strong> {user.email}</p>
+            <p><strong>Location:</strong> {user.location || 'N/A'}</p>
+            <p><strong>Bio:</strong> {user.bio || 'N/A'}</p>
+        </div>
+    );
+};
+
+export default UserProfileReadOnlyCard;

--- a/src/features/profile/UserProfileEditFormContainer.tsx
+++ b/src/features/profile/UserProfileEditFormContainer.tsx
@@ -4,8 +4,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { UserProfileEditFormValues, userProfileEditSchema } from '../../hooks/validation/user-profile-edit';
 import UserProfileEditForm from '../../components/profile/ProfileEditForm';
 import { mockUser } from "../../mock/user";
+import { getDefaultUserProfileValues } from "../../lib/user";
+import {messages} from "../../lib/messages";
 
-const UserProfileEditFormContainer: React.FC = () => {
+type Props = {
+    onComplete?: () => void;
+};
+
+const UserProfileEditFormContainer: React.FC<Props> = ({onComplete}) => {
     const [successMsg, setSuccessMsg] = useState('');
     const [errorMsg, setErrorMsg] = useState('');
     const [loading, setLoading] = useState(false);
@@ -16,12 +22,7 @@ const UserProfileEditFormContainer: React.FC = () => {
         formState: { errors },
     } = useForm<UserProfileEditFormValues>({
         resolver: zodResolver(userProfileEditSchema),
-        defaultValues: {
-            firstName: '',
-            lastName: '',
-            bio: '',
-            location: '',
-        },
+        defaultValues: getDefaultUserProfileValues(),
     });
 
     const onSubmit = async (data: UserProfileEditFormValues) => {
@@ -31,9 +32,12 @@ const UserProfileEditFormContainer: React.FC = () => {
 
         try {
             console.log('Submitting form:', data);
-            setSuccessMsg('Profile updated!');
-        } catch (err) {
-            setErrorMsg('Failed to update profile.');
+            setSuccessMsg(messages.success.update.profile.success);
+            if (onComplete) {
+                onComplete();
+            }
+        } catch {
+            setErrorMsg(messages.error.update.profile.default);
         } finally {
             setLoading(false);
         }
@@ -42,7 +46,10 @@ const UserProfileEditFormContainer: React.FC = () => {
     return (
         <UserProfileEditForm
             user={mockUser}
-            onChange={(updated) => reset((prev) => ({ ...prev, ...updated }), { keepErrors: true })}
+            onChange={(updated) =>
+                reset((prev) =>
+                    ({ ...prev, ...updated }), { keepErrors: true })
+            }
             onSubmit={handleSubmit(onSubmit)}
             successMsg={successMsg}
             errorMsg={Object.values(errors)[0]?.message || errorMsg}

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -16,6 +16,12 @@ export const messages = {
                 progress: 'Sending email...',
             }
         },
+        update: {
+            profile: {
+                success: 'Profile updated successfully!',
+                progress: 'Updating profile...',
+            }
+        }
     },
     error: {
         required: (field: string) =>  `${ field } is required.`,
@@ -63,5 +69,12 @@ export const messages = {
                 invalid: 'Invalid email address.',
             }
         },
+        update: {
+            profile: {
+                default: 'Profile update failed. Please try again.',
+                null: 'Profile data is required.',
+                invalid: 'Invalid profile data.'
+            }
+        }
     },
 };

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -8,3 +8,16 @@ export type User = {
     skills?: string[];
     profileImage?: string;
 };
+
+export function getDefaultUserProfileValues(): Partial<User> {
+    return {
+        firstName: '',
+        lastName: '',
+        email: '',
+        bio: '',
+        location: '',
+        skills: [],
+        profileImage: '',
+
+    };
+}

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -5,6 +5,8 @@ import { messages } from "../lib/messages";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import NotFound from "./NotFound";
 import { useAuth } from "../context/AuthContext";
+import UserProfileEditFormContainer from '../features/profile/UserProfileEditFormContainer';
+import UserProfileReadOnlyCard from '../components/profile/UserProfileReadOnlyCard';
 
 const UserProfilePage: React.FC = () => {
     const { user, setUser, loading } = useAuth();
@@ -12,6 +14,7 @@ const UserProfilePage: React.FC = () => {
     const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
     const [successMsg, setSuccessMsg] = useState<string | null>(null);
+    const [isEditing, setIsEditing] = useState<boolean>(false);
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -26,10 +29,8 @@ const UserProfilePage: React.FC = () => {
         reader.onloadend = () => {
             if (typeof reader.result === 'string') {
                 const newImage = reader.result;
-
                 setUploadedImageUrl(newImage);
                 setSuccessMsg(messages.success.upload.success);
-
                 setUser(prev => prev ? { ...prev, profileImage: newImage } : prev);
             }
         };
@@ -41,7 +42,7 @@ const UserProfilePage: React.FC = () => {
     if (!user) return <NotFound />;
 
     return (
-        <main className="bg-gray-100 min-h-screen py-10 px-4">
+        <main className="bg-gray-100 min-h-screen py-10 px-4 space-y-8">
             <ProfileImageUploader
                 user={user}
                 previewUrl={previewUrl}
@@ -50,6 +51,32 @@ const UserProfilePage: React.FC = () => {
                 errorMsg={errorMsg}
                 successMsg={successMsg}
             />
+
+            <div className="max-w-xl mx-auto">
+                <div className="flex justify-end mb-4">
+                    {isEditing ? (
+                        <button
+                            onClick={() => setIsEditing(false)}
+                            className="text-sm text-gray-600 hover:underline"
+                        >
+                            Cancel
+                        </button>
+                    ) : (
+                        <button
+                            onClick={() => setIsEditing(true)}
+                            className="text-sm text-blue-600 hover:underline"
+                        >
+                            Edit Profile
+                        </button>
+                    )}
+                </div>
+
+                {isEditing ? (
+                    <UserProfileEditFormContainer onComplete={() => setIsEditing(false)} />
+                ) : (
+                    <UserProfileReadOnlyCard user={user} />
+                )}
+            </div>
         </main>
     );
 };


### PR DESCRIPTION
### Changes:

- Created `UserProfileEditFormContainer.tsx` under `feature/profile`
- Integrated `react-hook-form` with `zodResolver` using `userProfileEditSchema`
- Managed form fields: `firstName`, `lastName`, `bio`, `location`
- Implemented `onSubmit` handler with loading, success, and error states
- Connected the container to the presentational `UserProfileEditForm` component
- Used a mock `user` object (`mockUser`) to decouple from context or external APIs during development