### PR TITLE
Implement basic user profile editing (name & bio only)

### DIFF
--- a/src/components/forms/registration-form/RegistrationForm.types.ts
+++ b/src/components/forms/registration-form/RegistrationForm.types.ts
@@ -3,5 +3,4 @@ export type RegistrationFormValues = {
     lastName: string;
     email: string;
     password: string;
-    value: string;
 };

--- a/src/components/profile/ProfileEditForm.tsx
+++ b/src/components/profile/ProfileEditForm.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { User } from '../../lib/user';
+
+export type UserProfileEditFormProps = {
+    user: User;
+    onChange: (updated: Partial<User>) => void;
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+    loading?: boolean;
+    successMsg?: string;
+    errorMsg?: string;
+};
+
+const UserProfileEditForm: React.FC<UserProfileEditFormProps> = ({
+         user,
+         onChange,
+         onSubmit,
+         loading = false,
+         successMsg,
+         errorMsg,
+   }) => {
+    return (
+        <form onSubmit={onSubmit} className="max-w-xl mx-auto p-6 bg-white shadow rounded space-y-4">
+            <h2 className="text-xl font-semibold text-center">Edit Profile</h2>
+
+            <div>
+                <label htmlFor="firstName" className="block text-sm font-medium text-gray-700">
+                    First Name
+                </label>
+                <input
+                    id="firstName"
+                    type="text"
+                    value={user.firstName}
+                    onChange={(e) => onChange({ firstName: e.target.value })}
+                    className="w-full border px-3 py-2 rounded"
+                    required
+                />
+            </div>
+
+            <div>
+                <label htmlFor="lastName" className="block text-sm font-medium text-gray-700">
+                    Last Name
+                </label>
+                <input
+                    id="lastName"
+                    type="text"
+                    value={user.lastName}
+                    onChange={(e) => onChange({ lastName: e.target.value })}
+                    className="w-full border px-3 py-2 rounded"
+                    required
+                />
+            </div>
+
+            <div>
+                <label htmlFor="organisation" className="block text-sm font-medium text-gray-700">
+                    Organisation
+                </label>
+                <input
+                    id="organisation"
+                    type="text"
+                    value={user.location || ''}
+                    onChange={(e) => onChange({ location: e.target.value })}
+                    className="w-full border px-3 py-2 rounded"
+                />
+            </div>
+
+            <div>
+                <label htmlFor="bio" className="block text-sm font-medium text-gray-700">
+                    Bio
+                </label>
+                <textarea
+                    id="bio"
+                    rows={4}
+                    value={user.bio || ''}
+                    onChange={(e) => onChange({ bio: e.target.value })}
+                    className="w-full border px-3 py-2 rounded"
+                />
+            </div>
+
+            {errorMsg && <p className="text-sm text-red-600">{errorMsg}</p>}
+            {successMsg && <p className="text-sm text-green-600">{successMsg}</p>}
+
+            <button
+                type="submit"
+                className="w-full bg-blue-600 text-white py-2 rounded disabled:opacity-50"
+                disabled={loading}
+            >
+                {loading ? 'Saving...' : 'Save Changes'}
+            </button>
+        </form>
+    );
+};
+
+export default UserProfileEditForm;

--- a/src/components/profile/UserProfileReadOnlyCard.tsx
+++ b/src/components/profile/UserProfileReadOnlyCard.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { User } from '../../lib/user';
+
+type Props = {
+    user: User;
+};
+
+const UserProfileReadOnlyCard: React.FC<Props> = ({ user }) => {
+    return (
+        <div className="bg-white p-6 rounded shadow space-y-2">
+            <p><strong>Name:</strong> {user.firstName} {user.lastName}</p>
+            <p><strong>Email:</strong> {user.email}</p>
+            <p><strong>Location:</strong> {user.location || 'N/A'}</p>
+            <p><strong>Bio:</strong> {user.bio || 'N/A'}</p>
+        </div>
+    );
+};
+
+export default UserProfileReadOnlyCard;

--- a/src/features/profile/UserProfileEditContainer.tsx
+++ b/src/features/profile/UserProfileEditContainer.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { UserProfileEditFormValues, userProfileEditSchema } from '../../hooks/validation/user-profile-edit';
+import UserProfileEditForm from '../../components/profile/ProfileEditForm';
+import { mockUser } from "../../mock/user";
+
+const UserProfileEditFormContainer: React.FC = () => {
+    const [successMsg, setSuccessMsg] = useState('');
+    const [errorMsg, setErrorMsg] = useState('');
+    const [loading, setLoading] = useState(false);
+
+    const {
+        handleSubmit,
+        reset,
+        formState: { errors },
+    } = useForm<UserProfileEditFormValues>({
+        resolver: zodResolver(userProfileEditSchema),
+        defaultValues: {
+            firstName: '',
+            lastName: '',
+            bio: '',
+            location: '',
+        },
+    });
+
+    const onSubmit = async (data: UserProfileEditFormValues) => {
+        setSuccessMsg('');
+        setErrorMsg('');
+        setLoading(true);
+
+        try {
+            console.log('Submitting form:', data);
+            setSuccessMsg('Profile updated!');
+        } catch (err) {
+            setErrorMsg('Failed to update profile.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <UserProfileEditForm
+            user={mockUser}
+            onChange={(updated) => reset((prev) => ({ ...prev, ...updated }), { keepErrors: true })}
+            onSubmit={handleSubmit(onSubmit)}
+            successMsg={successMsg}
+            errorMsg={Object.values(errors)[0]?.message || errorMsg}
+            loading={loading}
+        />
+    );
+};
+
+export default UserProfileEditFormContainer;

--- a/src/features/profile/UserProfileEditFormContainer.tsx
+++ b/src/features/profile/UserProfileEditFormContainer.tsx
@@ -6,6 +6,8 @@ import UserProfileEditForm from '../../components/profile/ProfileEditForm';
 import { mockUser } from "../../mock/user";
 import { getDefaultUserProfileValues } from "../../lib/user";
 import {messages} from "../../lib/messages";
+import { updateUserProfile } from "../../lib/user-profile";
+
 
 type Props = {
     onComplete?: () => void;
@@ -31,7 +33,8 @@ const UserProfileEditFormContainer: React.FC<Props> = ({onComplete}) => {
         setLoading(true);
 
         try {
-            console.log('Submitting form:', data);
+            const updatedUser = await updateUserProfile(data);
+            console.log('Updated user:', updatedUser);
             setSuccessMsg(messages.success.update.profile.success);
             if (onComplete) {
                 onComplete();

--- a/src/features/profile/UserProfileEditFormContainer.tsx
+++ b/src/features/profile/UserProfileEditFormContainer.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { UserProfileEditFormValues, userProfileEditSchema } from '../../hooks/validation/user-profile-edit';
 import UserProfileEditForm from '../../components/profile/ProfileEditForm';
-import { mockUser } from "../../mock/user";
 import { getDefaultUserProfileValues } from "../../lib/user";
 import {messages} from "../../lib/messages";
 import { updateUserProfile } from "../../lib/user-profile";
+import { useAuth } from "../../context/AuthContext";
 
 
 type Props = {
@@ -17,6 +17,7 @@ const UserProfileEditFormContainer: React.FC<Props> = ({onComplete}) => {
     const [successMsg, setSuccessMsg] = useState('');
     const [errorMsg, setErrorMsg] = useState('');
     const [loading, setLoading] = useState(false);
+    const { user } = useAuth();
 
     const {
         handleSubmit,
@@ -26,6 +27,17 @@ const UserProfileEditFormContainer: React.FC<Props> = ({onComplete}) => {
         resolver: zodResolver(userProfileEditSchema),
         defaultValues: getDefaultUserProfileValues(),
     });
+
+    useEffect(() => {
+        if (user) {
+            reset({
+                firstName: user.firstName || '',
+                lastName: user.lastName || '',
+                bio: user.bio || '',
+                location: user.location || '',
+            });
+        }
+    }, [user, reset]);
 
     const onSubmit = async (data: UserProfileEditFormValues) => {
         setSuccessMsg('');
@@ -48,7 +60,7 @@ const UserProfileEditFormContainer: React.FC<Props> = ({onComplete}) => {
 
     return (
         <UserProfileEditForm
-            user={mockUser}
+            user={user!}
             onChange={(updated) =>
                 reset((prev) =>
                     ({ ...prev, ...updated }), { keepErrors: true })

--- a/src/features/profile/UserProfileEditFormContainer.tsx
+++ b/src/features/profile/UserProfileEditFormContainer.tsx
@@ -4,8 +4,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { UserProfileEditFormValues, userProfileEditSchema } from '../../hooks/validation/user-profile-edit';
 import UserProfileEditForm from '../../components/profile/ProfileEditForm';
 import { mockUser } from "../../mock/user";
+import { getDefaultUserProfileValues } from "../../lib/user";
+import {messages} from "../../lib/messages";
 
-const UserProfileEditFormContainer: React.FC = () => {
+type Props = {
+    onComplete?: () => void;
+};
+
+const UserProfileEditFormContainer: React.FC<Props> = ({onComplete}) => {
     const [successMsg, setSuccessMsg] = useState('');
     const [errorMsg, setErrorMsg] = useState('');
     const [loading, setLoading] = useState(false);
@@ -16,12 +22,7 @@ const UserProfileEditFormContainer: React.FC = () => {
         formState: { errors },
     } = useForm<UserProfileEditFormValues>({
         resolver: zodResolver(userProfileEditSchema),
-        defaultValues: {
-            firstName: '',
-            lastName: '',
-            bio: '',
-            location: '',
-        },
+        defaultValues: getDefaultUserProfileValues(),
     });
 
     const onSubmit = async (data: UserProfileEditFormValues) => {
@@ -31,9 +32,12 @@ const UserProfileEditFormContainer: React.FC = () => {
 
         try {
             console.log('Submitting form:', data);
-            setSuccessMsg('Profile updated!');
-        } catch (err) {
-            setErrorMsg('Failed to update profile.');
+            setSuccessMsg(messages.success.update.profile.success);
+            if (onComplete) {
+                onComplete();
+            }
+        } catch {
+            setErrorMsg(messages.error.update.profile.default);
         } finally {
             setLoading(false);
         }
@@ -42,7 +46,10 @@ const UserProfileEditFormContainer: React.FC = () => {
     return (
         <UserProfileEditForm
             user={mockUser}
-            onChange={(updated) => reset((prev) => ({ ...prev, ...updated }), { keepErrors: true })}
+            onChange={(updated) =>
+                reset((prev) =>
+                    ({ ...prev, ...updated }), { keepErrors: true })
+            }
             onSubmit={handleSubmit(onSubmit)}
             successMsg={successMsg}
             errorMsg={Object.values(errors)[0]?.message || errorMsg}

--- a/src/hooks/validation/user-profile-edit.ts
+++ b/src/hooks/validation/user-profile-edit.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+import { messages } from '../../lib/messages';
+
+export const userProfileEditSchema = z.object({
+    firstName: z.string()
+        .nonempty(messages.error.required('First Name'))
+        .min(2, messages.error.min('First Name', 2)),
+
+    lastName: z.string()
+        .nonempty(messages.error.required('Last Name'))
+        .min(2, messages.error.min('Last Name', 2)),
+
+    bio: z.string()
+        .max(500, messages.error.max('Bio', 500))
+        .optional(),
+
+    location: z.string()
+        .max(255, messages.error.max('Location', 255))
+        .optional(),
+});
+
+export type UserProfileEditFormValues = z.infer<typeof userProfileEditSchema>;

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -16,6 +16,12 @@ export const messages = {
                 progress: 'Sending email...',
             }
         },
+        update: {
+            profile: {
+                success: 'Profile updated successfully!',
+                progress: 'Updating profile...',
+            }
+        }
     },
     error: {
         required: (field: string) =>  `${ field } is required.`,
@@ -63,5 +69,12 @@ export const messages = {
                 invalid: 'Invalid email address.',
             }
         },
+        update: {
+            profile: {
+                default: 'Profile update failed. Please try again.',
+                null: 'Profile data is required.',
+                invalid: 'Invalid profile data.'
+            }
+        }
     },
 };

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -8,3 +8,19 @@ export type UserProfile = {
     skills?: string[];
     profileImage?: string;
 };
+
+export async function updateUserProfile(data: Partial<UserProfile>): Promise<UserProfile> {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            console.log('Mock updated user:', data);
+            resolve({
+                id: 1,
+                email: 'test@example.com',
+                firstName: data.firstName || 'Taro',
+                lastName: data.lastName || 'Yamada',
+                bio: data.bio || '',
+                location: data.location || '',
+            });
+        }, 1000);
+    });
+}

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -8,3 +8,16 @@ export type User = {
     skills?: string[];
     profileImage?: string;
 };
+
+export function getDefaultUserProfileValues(): Partial<User> {
+    return {
+        firstName: '',
+        lastName: '',
+        email: '',
+        bio: '',
+        location: '',
+        skills: [],
+        profileImage: '',
+
+    };
+}

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -7,5 +7,4 @@ export type User = {
     location?: string;
     skills?: string[];
     profileImage?: string;
-
 };

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -5,6 +5,8 @@ import { messages } from "../lib/messages";
 import { ErrorMessage } from "../components/ui/ErrorMessage";
 import NotFound from "./NotFound";
 import { useAuth } from "../context/AuthContext";
+import UserProfileEditFormContainer from '../features/profile/UserProfileEditFormContainer';
+import UserProfileReadOnlyCard from '../components/profile/UserProfileReadOnlyCard';
 
 const UserProfilePage: React.FC = () => {
     const { user, setUser, loading } = useAuth();
@@ -12,6 +14,7 @@ const UserProfilePage: React.FC = () => {
     const [uploadedImageUrl, setUploadedImageUrl] = useState<string | null>(null);
     const [errorMsg, setErrorMsg] = useState<string | null>(null);
     const [successMsg, setSuccessMsg] = useState<string | null>(null);
+    const [isEditing, setIsEditing] = useState<boolean>(false);
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -26,10 +29,8 @@ const UserProfilePage: React.FC = () => {
         reader.onloadend = () => {
             if (typeof reader.result === 'string') {
                 const newImage = reader.result;
-
                 setUploadedImageUrl(newImage);
                 setSuccessMsg(messages.success.upload.success);
-
                 setUser(prev => prev ? { ...prev, profileImage: newImage } : prev);
             }
         };
@@ -41,7 +42,7 @@ const UserProfilePage: React.FC = () => {
     if (!user) return <NotFound />;
 
     return (
-        <main className="bg-gray-100 min-h-screen py-10 px-4">
+        <main className="bg-gray-100 min-h-screen py-10 px-4 space-y-8">
             <ProfileImageUploader
                 user={user}
                 previewUrl={previewUrl}
@@ -50,6 +51,32 @@ const UserProfilePage: React.FC = () => {
                 errorMsg={errorMsg}
                 successMsg={successMsg}
             />
+
+            <div className="max-w-xl mx-auto">
+                <div className="flex justify-end mb-4">
+                    {isEditing ? (
+                        <button
+                            onClick={() => setIsEditing(false)}
+                            className="text-sm text-gray-600 hover:underline"
+                        >
+                            Cancel
+                        </button>
+                    ) : (
+                        <button
+                            onClick={() => setIsEditing(true)}
+                            className="text-sm text-blue-600 hover:underline"
+                        >
+                            Edit Profile
+                        </button>
+                    )}
+                </div>
+
+                {isEditing ? (
+                    <UserProfileEditFormContainer onComplete={() => setIsEditing(false)} />
+                ) : (
+                    <UserProfileReadOnlyCard user={user} />
+                )}
+            </div>
         </main>
     );
 };


### PR DESCRIPTION
### ✅ Changes

- Implemented `UserProfileEditForm` and its container for form state
- Integrated `useAuth()` to retrieve and display current user data
- Applied Zod schema validation (`userProfileEditSchema`) for name and bio fields
- Added `reset()` to pre-fill the form using live user data
- Enabled optimistic UI updates using a mock `updateUserProfile` API
- Created `UserProfileReadOnlyCard` to toggle view-only mode
- Hooked into the overall `UserProfilePage` to toggle edit/read modes
