### PR TITLE
Add validation schema for post content submission

### DIFF
--- a/src/hooks/validation/post-submission.ts
+++ b/src/hooks/validation/post-submission.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { messages } from "../../lib/messages";
+
+export const postSubmissionSchema = z.object({
+    title: z.string()
+        .nonempty(messages.error.required('Title'))
+        .min(4, messages.error.min('Title', 4))
+        .max(255, messages.error.max('Title', 255)),
+
+    content: z.string()
+        .nonempty(messages.error.required('Content'))
+        .min(8, messages.error.min('Content', 8))
+        .max(255, messages.error.max('Content', 255))
+});
+
+export type PostSubmissionValues = z.infer<typeof postSubmissionSchema>;


### PR DESCRIPTION
### Changes:

- Created `postSubmissionSchema.ts` under `hooks/validation/`
- Defined Zod schema for `title` and `content` fields
  - `title`: required, 4–255 characters
  - `content`: required, 8–255 characters
- Added internationalised error messages using `messages.error`
- Exported `PostSubmissionValues` type via `z.infer`