### PR TITLE
Integrate post feed into Dashboard view

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LinkedIn</title>
   </head>

--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import Button from '../ui/Button';
+import PostFeed from '../post/PostFeed';
+import {mockPosts} from "../../mock/posts";
 
 type Props = {
     onLogout: () => void;
@@ -23,6 +25,12 @@ const Dashboard: React.FC<Props> = ({ onLogout, isLoggingOut, errorMsg }) => {
                 {errorMsg && (
                     <p className="text-red-500 mt-4">{errorMsg}</p>
                 )}
+            </section>
+            <section className="mt-10">
+                <h2 className="text-2xl font-bold text-gray-800 mb-4">Your Posts</h2>
+                <PostFeed
+                    posts={mockPosts}
+                />
             </section>
         </main>
     );

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -4,6 +4,8 @@ type PostCardProps = {
     content: string;
     authorName: string;
     createdAt: string;
+    likesCount?: number;
+    isLiked?: boolean;
 };
 
 const PostCard: React.FC<PostCardProps> = ({ content, authorName, createdAt }) => {

--- a/src/components/post/PostCard.tsx
+++ b/src/components/post/PostCard.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+type PostCardProps = {
+    content: string;
+    authorName: string;
+    createdAt: string;
+};
+
+const PostCard: React.FC<PostCardProps> = ({ content, authorName, createdAt }) => {
+    return (
+        <div className="bg-white rounded-xl shadow p-4 space-y-2">
+            <div className="text-sm text-gray-600">
+                <span className="font-medium">{authorName}</span>・{new Date(createdAt).toLocaleDateString()}
+            </div>
+            <p className="text-gray-800 whitespace-pre-line">{content}</p>
+        </div>
+    );
+};
+
+export default PostCard;

--- a/src/components/post/PostFeed.tsx
+++ b/src/components/post/PostFeed.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PostCard from './PostCard';
+
+export type Post = {
+    id: string;
+    content: string;
+    authorName: string;
+    createdAt: string;
+    likesCount?: number;
+    isLiked?: boolean;
+};
+
+type PostFeedProps = {
+    posts: Post[];
+};
+
+const PostFeed: React.FC<PostFeedProps> = ({ posts }) => {
+    if (posts.length === 0) {
+        return (
+            <p className="text-center text-gray-500 py-8">
+                No posts to display.
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            {posts.map((post) => (
+                <PostCard
+                    key={post.id}
+                    content={post.content}
+                    authorName={post.authorName}
+                    createdAt={post.createdAt}
+                    likesCount={post.likesCount ?? 0}
+                    isLiked={post.isLiked ?? false}
+                />
+            ))}
+        </div>
+    );
+};
+
+export default PostFeed;

--- a/src/components/post/PostFeed.tsx
+++ b/src/components/post/PostFeed.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import PostCard from './PostCard';
-
-export type Post = {
-    id: string;
-    content: string;
-    authorName: string;
-    createdAt: string;
-    likesCount?: number;
-    isLiked?: boolean;
-};
+import { Post } from '../../features/post/types/post.types';
 
 type PostFeedProps = {
     posts: Post[];

--- a/src/features/post/submit/type.ts
+++ b/src/features/post/submit/type.ts
@@ -1,0 +1,7 @@
+export type PostFormInput = {
+    content: string;
+};
+
+export type SubmitPostPayload = {
+    content: string;
+};

--- a/src/features/post/types/post.types.ts
+++ b/src/features/post/types/post.types.ts
@@ -1,0 +1,8 @@
+export type Post = {
+    id: string;
+    content: string;
+    authorName: string;
+    createdAt: string;
+    likesCount: number | null;
+    isLiked: boolean | null;
+};

--- a/src/mock/posts.ts
+++ b/src/mock/posts.ts
@@ -1,0 +1,20 @@
+import { Post } from '../features/post/types/post.types';
+
+export const mockPosts: Post[] = [
+    {
+        id: '1',
+        content: 'This is my first post!',
+        authorName: 'Alice',
+        createdAt: '2025-05-06T08:30:00Z',
+        likesCount: 3,
+        isLiked: false,
+    },
+    {
+        id: '2',
+        content: 'Enjoying the sunshine ☀️',
+        authorName: 'Bob',
+        createdAt: '2025-05-05T15:45:00Z',
+        likesCount: 10,
+        isLiked: true,
+    },
+];

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import logo from "../assets/react.svg";
 
 export const Landing: React.FC = () => {
     return (
@@ -29,9 +28,6 @@ export const Landing: React.FC = () => {
                             Learn More
                         </a>
                     </div>
-                </div>
-                <div className="md:w-1/2 flex justify-center">
-                    <img src={logo} alt="Logo" className="w-40 md:w-56"/>
                 </div>
             </section>
         </main>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,21 +1,40 @@
 import React from "react";
 import LoginForm from "../components/forms/login-form/LoginForm";
-import { Link } from 'react-router-dom';
+import { Link } from "react-router-dom";
+import { useForm } from "react-hook-form";
+
+type LoginFormValues = {
+    email: string;
+    password: string;
+};
 
 const Login = () => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<LoginFormValues>();
+
+    const onSubmit = (data: LoginFormValues) => {
+        console.log(data);
+    };
+
     return (
         <main className="flex items-center justify-center min-h-screen bg-gradient-to-tr from-indigo-100 via-purple-100 to-pink-100 px-4">
-            <section
-                className="w-full max-w-lg bg-white rounded-3xl shadow-xl p-10 flex flex-col gap-y-6"
-                aria-labelledby="login-heading"
-            >
+            <section className="w-full max-w-lg bg-white rounded-3xl shadow-xl p-10 flex flex-col gap-y-6">
                 <h1 className="text-4xl font-bold text-center text-gray-800 mb-4">
                     Log In
                 </h1>
                 <p className="text-center text-gray-600 mb-10">
                     Welcome back! Please log in to continue.
                 </p>
-                <LoginForm />
+                <LoginForm
+                    register={register}
+                    errors={errors}
+                    loading={false}
+                    errorMsg=""
+                    onSubmit={handleSubmit(onSubmit)}
+                />
                 <p className="text-sm text-center text-gray-500 mt-2 pt-8">
                     Don’t have an account?{" "}
                     <Link to="/register" className="text-indigo-600 hover:underline">

--- a/src/routes/AuthRoutes.tsx
+++ b/src/routes/AuthRoutes.tsx
@@ -2,6 +2,9 @@ import { RouteObject } from 'react-router-dom';
 import Register from '../pages/Register';
 import Login from '../pages/Login';
 import {Landing} from "../pages/Landing";
+import PasswordResetRequestForm from "../components/auth/PasswordResetRequestForm";
+import PasswordResetForm from "../components/auth/PasswordResetForm";
+import Dashboard from "../components/pages/Dashboard";
 
 export const authRoutes: RouteObject[] = [
     {
@@ -15,5 +18,30 @@ export const authRoutes: RouteObject[] = [
     {
         path: '/',
         element: <Landing />,
+    },
+    {
+        path: '/forgot-password',
+        element: <PasswordResetRequestForm />,
+    },
+    {
+        path: '/reset-password',
+        element: <PasswordResetForm
+            password={''}
+            confirmPassword={''}
+            onPasswordChange={() => {}}
+            onConfirmPasswordChange={() => {}}
+            onSubmit={() => {}}
+            loading={false}
+            errorMsg={''}
+            successMsg={''}
+        />,
+    },
+    {
+        path: '/dashboard',
+        element: <Dashboard
+            isLoggingOut={false}
+            errorMsg={''}
+            onLogout={() => {}}
+        />,
     }
 ];


### PR DESCRIPTION
### Changes
- Rendered `<PostFeed />` in `Dashboard.tsx` below the logout section
- Passed mock post data for testing and development purposes
- Ensured visual layout is consistent with the rest of the Dashboard
- Improved post rendering by falling back for `likesCount` and `isLiked` values

### Notes
- API integration for post feed will be handled in a separate issue
- The `PostFeed` component is already type-safe and accepts standardised post structures
- This is a presentational change with no backend logic yet involved