### PR TITLE
Add mock like state to PostFeed data

### DIFF
--- a/src/components/pages/Dashboard.tsx
+++ b/src/components/pages/Dashboard.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import Button from '../ui/Button';
 import PostFeed from '../post/PostFeed';
-import {mockPosts} from "../../mock/posts";
+import { mockPosts } from "../../mock/posts";
+import { Post } from "../../features/post/types/post.types";
 
 type Props = {
     onLogout: () => void;
     isLoggingOut: boolean;
     errorMsg: string;
+    posts: Post[];
 };
 
 const Dashboard: React.FC<Props> = ({ onLogout, isLoggingOut, errorMsg }) => {

--- a/src/features/dashboard/DashboardContainer.tsx
+++ b/src/features/dashboard/DashboardContainer.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { messages } from "../../lib/messages";
-import DashboardView from '../../components/pages/Dashboard';
+import Dashboard from '../../components/pages/Dashboard';
+import { mockPosts } from "../../mock/posts";
 
 const DashboardContainer: React.FC = () => {
     const { logout } = useAuth();
@@ -25,7 +26,8 @@ const DashboardContainer: React.FC = () => {
     };
 
     return (
-        <DashboardView
+        <Dashboard
+            posts={mockPosts}
             onLogout={handleLogout}
             isLoggingOut={isLoggingOut}
             errorMsg={errorMsg}


### PR DESCRIPTION
### Changes
- Updated `mockPosts` to include `likesCount` and `isLiked` fields
- Passed the enriched mock data from `DashboardContainer` to `DashboardView`
- Ensured `PostCard` receives correct props and displays LikeButton accordingly
- Resolved potential type mismatch by using `??` fallbacks in PostCard

### Notes
- This is a frontend-only implementation with no API integration
- LikeButton functionality is self-contained and mock-based for now
- Future enhancement will replace mock data with dynamic API-driven state