### PR TITLE
Scaffold placeholder API for fetching post feed

### DIFF
--- a/src/features/dashboard/DashboardContainer.tsx
+++ b/src/features/dashboard/DashboardContainer.tsx
@@ -1,16 +1,31 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { messages } from "../../lib/messages";
 import Dashboard from '../../components/pages/Dashboard';
-import { mockPosts } from "../../mock/posts";
+import { fetchFeed } from "../../lib/post-feed";
+import { Post } from '../../features/post/types/post.types';
 
 const DashboardContainer: React.FC = () => {
     const { logout } = useAuth();
     const navigate = useNavigate();
 
+    const [posts, setPosts] = useState<Post[]>([]);
     const [errorMsg, setErrorMsg] = useState('');
     const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+    useEffect(() => {
+        const loadFeed = async () => {
+            try {
+                const data = await fetchFeed();
+                setPosts(data);
+            } catch (err) {
+                console.error(err);
+                setErrorMsg("Failed to load feed.");
+            }
+        };
+        loadFeed();
+    }, []);
 
     const handleLogout = async () => {
         try {
@@ -27,7 +42,7 @@ const DashboardContainer: React.FC = () => {
 
     return (
         <Dashboard
-            posts={mockPosts}
+            posts={posts}
             onLogout={handleLogout}
             isLoggingOut={isLoggingOut}
             errorMsg={errorMsg}

--- a/src/lib/post-feed.ts
+++ b/src/lib/post-feed.ts
@@ -1,0 +1,8 @@
+import { Post } from '../features/post/types/post.types';
+import { mockPosts } from '../mock/posts';
+
+export const fetchFeed = async (): Promise<Post[]> => {
+    return new Promise((resolve) => {
+        setTimeout(() => resolve(mockPosts), 300);
+    });
+};


### PR DESCRIPTION
### Changes
- Created `fetchFeed()` function to simulate `/api/feed` behaviour
- Returned mock post data (`mockPosts`) with artificial delay
- Integrated the placeholder API into `DashboardContainer` via `useEffect`
- Updated local state to handle feed data and fallback error state
- Used type-safe `Post[]` as return type for consistency and reusability

### Notes
- The actual backend call will be implemented later
- This function enables frontend developers to continue building UI components without waiting for backend readiness
- Feed data source is now encapsulated in a reusable abstraction